### PR TITLE
Variable naming convention, type hints, minor polish

### DIFF
--- a/src/game_monitor.py
+++ b/src/game_monitor.py
@@ -13,41 +13,39 @@ class GameMonitor:
     process = None
 
     def __init__(self) -> None:
-        if not GameMonitor.process:
-            GameMonitor.get_process()
+        if not self.process:
 
     def get_create_time(self):
-        return GameMonitor.process.create_time()
+        return self.process.create_time()
 
     def is_user_active(self) -> bool:
-        return GameMonitor.user_active
+        return self.user_active
 
     @classmethod
     def get_process(cls) -> Optional[psutil.Process]:
-        for proc in psutil.process_iter():
-            if "GenshinImpact.exe" in proc.name():
-                    GameMonitor.process = proc
-                    return proc
+        for process in psutil.process_iter():
+            if "GenshinImpact.exe" in process.name():
+                    cls.process = process
+                    return process
             
         return None
 
     @classmethod
     def wait_for_game(cls):
-        logger.info("Searching for game process")
-        while not GameMonitor.process:
-            GameMonitor.get_process()
-            logger.info("Game process not found, waiting for 3s...")
+        cls.logger.info("Waiting for game process")
+        while not cls.get_process():
+            cls.logger.info("Game process not found, waiting for 3s...")
             time.sleep(3)
 
     def check_changed_focus(self) -> bool:
-        changed: bool = GameMonitor.user_active
+        changed: bool = self.user_active
 
         if win32gui.GetWindowText(win32gui.GetForegroundWindow()) == "Genshin Impact":  # type: ignore[name-defined, unused-ignore] # Temp. workaround
-            GameMonitor.user_active = True
+            self.user_active = True
         else:
-            GameMonitor.user_active = False
+            self.user_active = False
 
-        changed = changed != GameMonitor.user_active
+        changed = changed != self.user_active
         if changed:
-            logger.debug(f"Updated user_active status to {GameMonitor.user_active}")
+            self._logger.debug(f"Updated user_active status to {self.user_active}")
         return changed

--- a/src/game_monitor.py
+++ b/src/game_monitor.py
@@ -31,10 +31,7 @@ class GameMonitor:
         return None
 
     @classmethod
-    def wait_for_game(cls):
-        cls.logger.info("Waiting for game process")
-        while not cls.get_process():
-            cls.logger.info("Game process not found, waiting for 3s...")
+    def wait_for_game(cls) -> None:
             time.sleep(3)
 
     def check_changed_focus(self) -> bool:

--- a/src/interaction_manager.py
+++ b/src/interaction_manager.py
@@ -5,38 +5,42 @@ import os
 
 
 class InteractionManager:
-    def save_ini_file(self, config_parser: ConfigParser, ini_file: str) -> None:
+    @classmethod
+    def save_ini_file(cls, config_parser: ConfigParser, ini_file: str, game_dir: str) -> None:
         if not os.path.exists(os.path.dirname(ini_file)):
             os.mkdir(os.path.dirname(ini_file))
 
         if not config_parser.has_section("SETTINGS"):
             config_parser.add_section("SETTINGS")
-        config_parser["SETTINGS"]["GIMI_DIRECTORY"] = config.GIMI_DIRECTORY
+        config_parser["SETTINGS"]["GIMI_DIRECTORY"] = game_dir
 
         with open(ini_file, "w") as file:
             config_parser.write(file)
 
     @classmethod
-    def check_gimi_dir(cls) -> None:
-        config_parser = ConfigParser()
+    def check_gimi_dir(cls) -> str:
+        config_parser: ConfigParser = ConfigParser()
         ini_file: str = f"{tempfile.gettempdir()}\\GenshinRichPresence\\config.ini"
+        game_dir: str = ""
 
         if not os.path.exists(ini_file):
             print("\nPlease write here your GIMI directory path")
-            config.GIMI_DIRECTORY = input(" > ")
-            cls.save_ini_file(config_parser, ini_file)
-            return
-        
-        config_parser.read(ini_file)
-        config.GIMI_DIRECTORY = config_parser.get("SETTINGS", "GIMI_DIRECTORY")
+            game_dir = input(" > ")
+            cls.save_ini_file(config_parser, ini_file, game_dir)
+            return game_dir
 
-        print(f"\nGIMI directory found: {config.GIMI_DIRECTORY}")
+        config_parser.read(ini_file)
+        game_dir = config_parser.get("SETTINGS", "GIMI_DIRECTORY")
+
+        print(f"\nGIMI directory found: {game_dir}")
         print("Press ENTER if you wanna keep it. Otherwise, write the new directory")
-        response = input(" > ")
+        response: str = input(" > ")
 
         if not response:
             config_parser.read(ini_file)
-            config.GIMI_DIRECTORY = config_parser.get("SETTINGS", "GIMI_DIRECTORY")
+            game_dir = config_parser.get("SETTINGS", "GIMI_DIRECTORY")
         else:
-            config.GIMI_DIRECTORY = response
-            cls.save_ini_file(config_parser, ini_file)
+            game_dir = response
+            cls.save_ini_file(config_parser, ini_file, game_dir)
+
+        return game_dir

--- a/src/interaction_manager.py
+++ b/src/interaction_manager.py
@@ -32,11 +32,11 @@ class InteractionManager:
 
         print(f"\nGIMI directory found: {config.GIMI_DIRECTORY}")
         print("Press ENTER if you wanna keep it. Otherwise, write the new directory")
-        answer = input(" > ")
+        response = input(" > ")
 
-        if not answer:
+        if not response:
             config_parser.read(ini_file)
             config.GIMI_DIRECTORY = config_parser.get("SETTINGS", "GIMI_DIRECTORY")
         else:
-            config.GIMI_DIRECTORY = answer
+            config.GIMI_DIRECTORY = response
             cls.save_ini_file(config_parser, ini_file)

--- a/src/log_monitor.py
+++ b/src/log_monitor.py
@@ -1,5 +1,5 @@
 from io import TextIOWrapper
-from typing import Generator, Any
+from typing import Generator, Any, Final
 import os
 import time
 import config
@@ -8,14 +8,13 @@ from rich_presence import DiscordRichPresence
 
 
 class LogMonitor:
-    def __init__(self, log_dir) -> None:
+    def __init__(self, log_dir: str) -> None:
         self._logger: logging.Logger = logging.getLogger(__name__)
 
         if not os.path.exists(log_dir):
             raise FileNotFoundError("Could not find the game log")
 
-        self.LOG_DIR = log_dir
-        self.rpc = DiscordRichPresence()
+        self.rpc: DiscordRichPresence = DiscordRichPresence()
 
         self._logger.info("Opening log file")
 
@@ -31,10 +30,10 @@ class LogMonitor:
         self.handle_log()
 
     def get_file_size(self) -> int:
-        current_cursor_position: int = self._log_file.tell()
+        current_cursor_position: Final[int] = self._log_file.tell()
         self._log_file.seek(os.SEEK_SET, os.SEEK_END)
 
-        size: int = self._log_file.tell()
+        size: Final[int] = self._log_file.tell()
         self._log_file.seek(current_cursor_position)
 
         return size
@@ -50,7 +49,7 @@ class LogMonitor:
 
     def tail_file(self) -> Generator[str, Any, None]:
         while True:
-            line = self._log_file.readline()
+            line: str = self._log_file.readline()
 
             if line:
                 yield line
@@ -63,6 +62,7 @@ class LogMonitor:
             time.sleep(config.LOG_TAIL_SLEEP_TIME)
         
     def handle_log(self) -> None:
+        line: str
         for line in self.tail_file():
             # Ignore lines we do not need
             if (

--- a/src/log_monitor.py
+++ b/src/log_monitor.py
@@ -17,6 +17,7 @@ class LogMonitor:
         self.rpc: DiscordRichPresence = DiscordRichPresence()
 
         self._logger.info("Opening log file")
+        self._log_file: TextIOWrapper = self.open_log_file(log_dir)
 
     def start(self) -> None:
         if self.get_file_size() > 5000000:
@@ -41,11 +42,11 @@ class LogMonitor:
     def seek_back_n_bytes_from_end(self, n_bytes: int) -> None:
         self._log_file.seek(self.get_file_size() - n_bytes, os.SEEK_SET)
 
-    def open_log_file(self) -> TextIOWrapper:
-        if not os.path.exists(self.LOG_DIR):
-            raise FileNotFoundError(f'The file "{self.LOG_DIR}" could not be found')
+    def open_log_file(self, log_dir: str) -> TextIOWrapper:
+        if not os.path.exists(log_dir):
+            raise FileNotFoundError(f'The file "{log_dir}" could not be found')
 
-        return open(self.LOG_DIR, "r")
+        return open(log_dir, "r")
 
     def tail_file(self) -> Generator[str, Any, None]:
         while True:
@@ -60,7 +61,7 @@ class LogMonitor:
                 self.rpc.update_rpc()
 
             time.sleep(config.LOG_TAIL_SLEEP_TIME)
-        
+
     def handle_log(self) -> None:
         line: str
         for line in self.tail_file():

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class GenshinRichPresence:
-    def start(self):
+    def start(self) -> None:
         sys.excepthook = exception_handler
         InteractionManager.check_gimi_dir()
         GameMonitor.wait_for_game()

--- a/src/rich_presence.py
+++ b/src/rich_presence.py
@@ -18,7 +18,7 @@ class DiscordRichPresence(pypresence.Presence):
 
     def __init__(self) -> None:
         super().__init__(config.APP_ID)
-        self.logger = logging.getLogger(__name__)
+        self._logger = logging.getLogger(__name__)
 
         self.connect()
         self.game_monitor = GameMonitor()
@@ -40,11 +40,11 @@ class DiscordRichPresence(pypresence.Presence):
         # Workaround: Fixes the incorrect displayed region as Liyue when the player is on The Chasm
         # Issue #27: https://github.com/Artprozew/GenshinRichPresence/issues/27
         if self.current_region == "Liyue" and self.previous_region == "The Chasm":
-            self.logger.debug("Setting region as the_chasm instead of liyue to workaround #27")
+            self._logger.debug("Setting region as the_chasm instead of liyue to workaround #27")
             self.current_region = "The Chasm"
 
-        is_player_active = "In-Game" if self.game_monitor.is_user_active else "Inactive"
-        self.details = f"{is_player_active}. Exploring {self.current_region}"
+        is_user_active = "In-Game" if self.game_monitor.is_user_active() else "Inactive"
+        self.details = f"{is_user_active}. Exploring {self.current_region}"
 
         self.update(
             start=self.game_monitor.get_create_time(),  # type: ignore # Needs rework of class and better logic with None
@@ -58,4 +58,4 @@ class DiscordRichPresence(pypresence.Presence):
 
         self.set_last_update()
         self.updatable = False
-        self.logger.debug("RPC Updated")
+        self._logger.debug("RPC Updated")

--- a/src/rich_presence.py
+++ b/src/rich_presence.py
@@ -3,25 +3,28 @@ import time
 import pypresence
 import logging
 from game_monitor import GameMonitor
+from typing import Final, Any
+
+
 class DiscordRichPresence(pypresence.Presence):
-    start = 0
-    state = "Unknown"
-    details = "Unknown"
-    large_image = "Unknown"
-    small_image = "Unknown"
-    large_text = "Unknown"
-    small_text = "Unknown"
-    previous_region = "Unknown"
-    current_region = "Unknown"
-    current_character = "Unknown"
-    updatable = False
+    start: int = 0
+    state: str = "Unknown"
+    details: str = "Unknown"
+    large_image: str = "Unknown"
+    small_image: str = "Unknown"
+    large_text: str = "Unknown"
+    small_text: str = "Unknown"
+    previous_region: str = "Unknown"
+    current_region: str = "Unknown"
+    current_character: str = "Unknown"
+    updatable: bool = False
 
     def __init__(self) -> None:
         super().__init__(config.APP_ID)
-        self._logger = logging.getLogger(__name__)
+        self._logger: logging.Logger = logging.getLogger(__name__)
 
         self.connect()
-        self.game_monitor = GameMonitor()
+        self.game_monitor: GameMonitor = GameMonitor()
     def can_update_rpc(self) -> bool:
         if (time.time() - self.last_update) > config.RPC_UPDATE_RATE:
             return self.game_monitor.check_changed_focus() or self.updatable
@@ -43,7 +46,7 @@ class DiscordRichPresence(pypresence.Presence):
             self._logger.debug("Setting region as the_chasm instead of liyue to workaround #27")
             self.current_region = "The Chasm"
 
-        is_user_active = "In-Game" if self.game_monitor.is_user_active() else "Inactive"
+        is_user_active: Final[str] = "In-Game" if self.game_monitor.is_user_active() else "Inactive"
         self.details = f"{is_user_active}. Exploring {self.current_region}"
 
         self.update(

--- a/src/utils/exception_manager.py
+++ b/src/utils/exception_manager.py
@@ -4,6 +4,7 @@ import os
 import sys
 import traceback
 
+
 def exception_handler(exc_type: Any, exc_value: Any, tb: Any) -> None:
     with open(f"{tempfile.gettempdir()}\\GenshinRichPresence\\traceback.txt", "w") as file:
         for line in traceback.format_exception(exc_type, exc_value, tb):


### PR DESCRIPTION
This PR makes changes on variable names to promote adherence to the project's naming convention:

- `_name` can/will be used as "private" class attribute. Double underscore is discouraged but can be used in rare occasions.
- All uppercase names will only be used for constants defined at [module-level](https://peps.python.org/pep-0008/#constants). Otherwise, `typing.Final` can be used at any scope provided they are not reassigned anywhere.

Some missing type-hints were also added as a follow-up from PR (#30).